### PR TITLE
Replaced render_partial with render for Mojolicious 4.0 compatibility

### DIFF
--- a/lib/Mojolicious/Plugin/LinkedContent.pm
+++ b/lib/Mojolicious/Plugin/LinkedContent.pm
@@ -83,10 +83,11 @@ sub include_js {
 
         $c->stash('$linked_item' => $self->_prepend_path($_, 'js_base'));
 
-        push @ct, $c->render_partial(
+        push @ct, $c->render(
             template => 'LinkedContent/js',
             format   => 'html',
             handler  => 'ep',
+            partial  => 1,
 
             # template_class is deprecated since Mojolicious 2.62
             # was removed at some point which broke my code.
@@ -110,10 +111,11 @@ sub include_css {
 
         $c->stash('$linked_item' => $self->_prepend_path($_, 'css_base'));
 
-        push @ct, $c->render_partial(
+        push @ct, $c->render(
             template => 'LinkedContent/css',
             format   => 'html',
             handler  => 'ep',
+            partial  => 1,
 
             # template_class is deprecated since Mojolicious 2.62
             # was removed at some point which broke my code.


### PR DESCRIPTION
[Mojolicious 4.0](https://github.com/kraih/mojo/blob/master/Changes) removed Mojolicious::Controller->render_partial.

Switched to the recommended $controller->render(... , partial => 1)
