### PR TITLE
Replaced render with render_to_string

### DIFF
--- a/lib/Mojolicious/Plugin/LinkedContent.pm
+++ b/lib/Mojolicious/Plugin/LinkedContent.pm
@@ -83,11 +83,10 @@ sub include_js {
 
         $c->stash('$linked_item' => $self->_prepend_path($_, 'js_base'));
 
-        push @ct, $c->render(
+        push @ct, $c->render_to_string(
             template => 'LinkedContent/js',
             format   => 'html',
             handler  => 'ep',
-            partial  => 1,
 
             # template_class is deprecated since Mojolicious 2.62
             # was removed at some point which broke my code.
@@ -111,11 +110,10 @@ sub include_css {
 
         $c->stash('$linked_item' => $self->_prepend_path($_, 'css_base'));
 
-        push @ct, $c->render(
+        push @ct, $c->render_to_string(
             template => 'LinkedContent/css',
             format   => 'html',
             handler  => 'ep',
-            partial  => 1,
 
             # template_class is deprecated since Mojolicious 2.62
             # was removed at some point which broke my code.


### PR DESCRIPTION
Mojolicious 5 replaced the partial rendering using the `render` helper
with a `render_to_string` helper.

This commit updates the plugin to reflect that change.

For more information, see this post by sri:
https://groups.google.com/d/msg/mojolicious/PYfjHyVj26w/jrWH33bcuV4J
